### PR TITLE
Update SDL.cpp

### DIFF
--- a/RetroFE/Source/SDL.cpp
+++ b/RetroFE/Source/SDL.cpp
@@ -131,7 +131,7 @@ bool SDL::initialize( Configuration &config )
                 Logger::write( Logger::ZONE_ERROR, "Configuration", "Missing property \"horizontal\"" + std::to_string(i) );
                 return false;
             }
-            else if ( hString != "stretch" && (i == 0 && !config.getProperty( "horizontal", windowWidth_[i] )) && !config.getProperty( "horizontal" + std::to_string(i), windowWidth_[i] ))
+            else if ( hString != "stretch" && (i == screenNum && !config.getProperty( "horizontal", windowWidth_[i] )) && !config.getProperty( "horizontal" + std::to_string(i), windowWidth_[i] ))
             {
                 Logger::write( Logger::ZONE_ERROR, "Configuration", "Invalid property value for \"horizontal\"" + std::to_string(i) );
                 return false;
@@ -148,7 +148,7 @@ bool SDL::initialize( Configuration &config )
                 Logger::write( Logger::ZONE_ERROR, "Configuration", "Missing property \"vertical\"" + std::to_string(i) );
                 return false;
             }
-            else if ( vString != "stretch" && (i == 0 && !config.getProperty( "vertical", windowHeight_[i] )) && !config.getProperty( "vertical" + std::to_string(i), windowHeight_[i] ) )
+            else if ( vString != "stretch" && (i == screenNum && !config.getProperty( "vertical", windowHeight_[i] )) && !config.getProperty( "vertical" + std::to_string(i), windowHeight_[i] ) )
             {
                 Logger::write( Logger::ZONE_ERROR, "Configuration", "Invalid property value for \"vertical\"" + std::to_string(i) );
                 return false;


### PR DESCRIPTION
settings info for tests

numScreens             = 2
screenNum0             = 0
screenNum1             = 1

fullscreen0            = no       
horizontal0            = 1280
vertical0              = 720

fullscreen1            = no       
horizontal1            = 1280     
vertical1              = 1024 
if line 134 and 151 i==0 
1st screen will resize 2nd screen stretch

if i change line 134 and  151 i ==0 to i==screenNum,
it will start  1st  and  2nd screen resize, 
so this i==0 for what i understand only do settings info to Horizontal0 and Vertical0

problably line 160 fullscreen needs same change!?