### PR TITLE
Fix GSTREAMER_ROOT variable in CMakeLists.txt

### DIFF
--- a/RetroFE/Source/CMakeLists.txt
+++ b/RetroFE/Source/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 	set(ZLIB_ROOT "${RETROFE_THIRD_PARTY_DIR}/zlib128-dll")
 
-	set(GSTREAMER_ROOT "C:/gstreamer/1.0/x86" CACHE STRING "location of where your gstreamer include and lib folders reside")
+	set(GSTREAMER_ROOT "C:/gstreamer/1.0/msvc_x86" CACHE STRING "location of where your gstreamer include and lib folders reside")
 	set(GLIB2_ROOT "${GSTREAMER_ROOT}")
   
 if(MSVC)  


### PR DESCRIPTION
Newer versions of gstreamer changed where the development files are stored. (i.e. - C:\gstreamer\1.0\msvc_x86)
This simple change fixes the CMakeLists.txt to point to the correct path.